### PR TITLE
Implement retrieval of latest prompt by name

### DIFF
--- a/DotPrompt.Sql/SqlPromptRepository.cs
+++ b/DotPrompt.Sql/SqlPromptRepository.cs
@@ -137,7 +137,7 @@ public class SqlPromptRepository(IDbConnection connection) : IPromptRepository
         string? query = DatabaseConfigReader.LoadQuery("GetLatestPromptByName.sql");
         if (string.IsNullOrEmpty(query))
         {
-            return null;
+            throw new InvalidOperationException("Failed to load SQL query file 'GetLatestPromptByName.sql'. The file could not be found or loaded.");
         }
 
         // Retrieve the prompt row

--- a/DotPrompt.Sql/SqlPromptRepository.cs
+++ b/DotPrompt.Sql/SqlPromptRepository.cs
@@ -188,7 +188,11 @@ WHERE pp.PromptId = @PromptId
 
                 if (param.DefaultValue != null && !prompt.Default.ContainsKey(param.ParameterName))
                 {
-                    prompt.Default.Add(param.ParameterName, param.DefaultValue);
+                prompt.Parameters.TryAdd(param.ParameterName, param.ParameterValue);
+
+                if (param.DefaultValue != null)
+                {
+                    prompt.Default.TryAdd(param.ParameterName, param.DefaultValue);
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add GetLatestPromptByName to fetch latest prompt with parameters and defaults

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9e07ed68832c93fdab23be09e04a