### PR TITLE
Fix release workflow to trigger on tag push and use tag as version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,9 @@
 name: release
 
 on:
-  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   build:
@@ -15,14 +17,12 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: 9.0.x
-    - name: Get latest tag version
+    - name: Get version from tag
       id: vars
-      run: echo "tag=$(git describe --tags --abbrev=0)" >> $GITHUB_ENV
+      run: echo "RELEASE_VERSION=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
     - name: Package
-      env:
-        RELEASE_VERSION: ${{ env.tag }}
       run: |
         echo "Release version: $RELEASE_VERSION"
-        dotnet pack -p:PackageVersion=0.2.2
+        dotnet pack -p:PackageVersion=$RELEASE_VERSION
         dotnet nuget push DotPrompt.Sql/nupkg/*.nupkg -k ${{ secrets.AZURECODER_NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
 


### PR DESCRIPTION
- Trigger on 'v*' tag push instead of manual workflow_dispatch
- Derive PackageVersion from the tag (strips leading 'v') using GITHUB_REF_NAME
- Remove hardcoded 0.2.2 version

Usage: push a tag like 'v0.2.3' to trigger a NuGet release at that version.